### PR TITLE
Feature #10 get posts (supabase realtime)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        hostname: "picsum.photos",
+      },
+      {
+        hostname: "imagedelivery.net",
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@heroicons/react": "^2.1.5",
         "@hookform/resolvers": "^3.9.0",
+        "@supabase/supabase-js": "^2.45.2",
         "bcrypt": "^5.1.1",
         "date-fns": "^3.6.0",
         "iron-session": "^8.0.3",
@@ -527,6 +528,73 @@
       "integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==",
       "dev": true
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.64.4",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.64.4.tgz",
+      "integrity": "sha512-9ITagy4WP4FLl+mke1rchapOH0RQpf++DI+WSG2sO1OFOZ0rW3cwAM0nCrMOxu+Zw4vJ4zObc08uvQrXx590Tg==",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.1.tgz",
+      "integrity": "sha512-8sZ2ibwHlf+WkHDUZJUXqqmPvWQ3UHN0W30behOJngVh/qHHekhJLCFbh0AjkE9/FqqXtf9eoVvmYgfCLk5tNA==",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.15.8.tgz",
+      "integrity": "sha512-YunjXpoQjQ0a0/7vGAvGZA2dlMABXFdVI/8TuVKtlePxyT71sl6ERl6ay1fmIeZcqxiuFQuZw/LXUuStUG9bbg==",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.10.2.tgz",
+      "integrity": "sha512-qyCQaNg90HmJstsvr2aJNxK2zgoKh9ZZA8oqb7UT2LCh3mj9zpa3Iwu167AuyNxsxrUE8eEJ2yH6wLCij4EApA==",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14",
+        "@types/phoenix": "^1.5.4",
+        "@types/ws": "^8.5.10",
+        "ws": "^8.14.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.0.tgz",
+      "integrity": "sha512-iZenEdO6Mx9iTR6T7wC7sk6KKsoDPLq8rdu5VRy7+JiT1i8fnqfcOr6mfF2Eaqky9VQzhP8zZKQYjzozB65Rig==",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.45.2",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.45.2.tgz",
+      "integrity": "sha512-kJKY3ISFusVKQWCP8Kqo20Ebxy2WLp6Ry/Suco0aQsPXH7bvn7clswsdhcfcH/5Tr0MYz/jcCjF0n/27SetiCw==",
+      "dependencies": {
+        "@supabase/auth-js": "2.64.4",
+        "@supabase/functions-js": "2.4.1",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.15.8",
+        "@supabase/realtime-js": "2.10.2",
+        "@supabase/storage-js": "2.7.0"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -560,7 +628,6 @@
       "version": "20.16.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.1.tgz",
       "integrity": "sha512-zJDo7wEadFtSyNz5QITDfRcrhqDvQI1xQNQ0VoizPjM/dVAODqqIUWbJPkvsxmTI0MYRGRikcdjMPhOssnPejQ==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -574,6 +641,11 @@
         "@types/node": "*",
         "form-data": "^4.0.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.5.tgz",
+      "integrity": "sha512-xegpDuR+z0UqG9fwHqNoy3rI7JDlvaPh2TY47Fl80oq6g+hXT+c/LEuE43X48clZ6lOfANl5WrPur9fYO1RJ/w=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
@@ -598,6 +670,14 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
+      "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -5346,8 +5426,7 @@
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -5613,6 +5692,26 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build ",
     "start": "next start",
     "lint": "next lint"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@heroicons/react": "^2.1.5",
     "@hookform/resolvers": "^3.9.0",
+    "@supabase/supabase-js": "^2.45.2",
     "bcrypt": "^5.1.1",
     "date-fns": "^3.6.0",
     "iron-session": "^8.0.3",

--- a/prisma/migrations/20240825112732_update_ai_comment_model/migration.sql
+++ b/prisma/migrations/20240825112732_update_ai_comment_model/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "AiComment" DROP CONSTRAINT "AiComment_aiBotId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "AiComment" DROP CONSTRAINT "AiComment_postId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "AiComment" ADD CONSTRAINT "AiComment_aiBotId_fkey" FOREIGN KEY ("aiBotId") REFERENCES "AiBot"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AiComment" ADD CONSTRAINT "AiComment_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -111,9 +111,9 @@ model AiComment {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  aiBot   AiBot @relation(fields: [aiBotId], references: [id])
+  aiBot   AiBot @relation(fields: [aiBotId], references: [id], onDelete: Cascade)
   aiBotId Int
-  Post    Post  @relation(fields: [postId], references: [id])
+  Post    Post  @relation(fields: [postId], references: [id], onDelete: Cascade)
   postId  Int
 
   @@index([aiBotId])

--- a/src/app/(tab)/page.tsx
+++ b/src/app/(tab)/page.tsx
@@ -2,15 +2,21 @@ import Link from "next/link";
 import { ChevronRightIcon } from "@heroicons/react/24/solid";
 
 import PostList from "@/components/post/post-list";
-import { getInitialPosts } from "@/service/postService";
+import getMostPopularCategoryPosts, { getInitialPosts } from "@/service/postService";
+import InfinitePostList from "@/components/post/infinite-post-list";
+import { getMostPopularCategory } from "@/service/categoryService";
+import { CATEGORIES } from "@/constants/cateogries";
 
 export default async function Home() {
-  const posts = await getInitialPosts();
+  const mostPopularCategoryPosts = await getMostPopularCategoryPosts();
+  const category = await getMostPopularCategory();
+  const { items: initialInfinitePosts, cursorId: initialInfiniteCursorId } = await getInitialPosts();
   return (
     <main className="flex flex-col gap-4">
       <div className="w-full h-96 bg-underline"></div>
       <div className="flex gap-2 pl-5 overflow-y-scroll">
-        {["전체", "운동", "식단", "기상", "독서", "기타"].map((category) => (
+        {/* #TODO 카테고리당 post list 페이지 생성 후 수정 필요 */}
+        {["전체", ...Object.values(CATEGORIES)].map((category) => (
           <div className="bg-primary text-white px-4 py-2 min-w-fit rounded-2xl text-md font-bold" key={category}>
             {category}
           </div>
@@ -20,12 +26,13 @@ export default async function Home() {
         <div className="flex flex-col gap-2">
           <p className="font-semibold text-xs pl-2">제일 인증수가 많은 주제에 함께 하세요!</p>
           <div className="flex justify-between px-2">
-            <h3 className="font-extrabold text-md pb-2">최근 다미가 응원한 운동 인증</h3>
-            <Link href={"/posts/exercise"} className="text-base flex items-center text-xs">
+            <h3 className="font-extrabold text-md pb-2">최근 다미가 응원한 {CATEGORIES[category]} 인증</h3>
+            {/* #TODO 카테고리당 post list 페이지 생성 후 수정 필요 */}
+            <Link href={`/posts`} className="text-base flex items-center text-xs">
               <span>더보기</span> <ChevronRightIcon className="w-4 h-3" />
             </Link>
           </div>
-          <PostList />
+          <PostList initialPosts={mostPopularCategoryPosts} />
         </div>
         <div className="flex flex-col gap-4">
           <div className="flex justify-between px-2">
@@ -34,7 +41,7 @@ export default async function Home() {
               <span>더보기</span> <ChevronRightIcon className="w-4 h-3" />
             </Link>
           </div>
-          <PostList />
+          <InfinitePostList initialPosts={initialInfinitePosts} initialCursorId={initialInfiniteCursorId} />
         </div>
       </div>
     </main>

--- a/src/app/(tab)/page.tsx
+++ b/src/app/(tab)/page.tsx
@@ -2,8 +2,10 @@ import Link from "next/link";
 import { ChevronRightIcon } from "@heroicons/react/24/solid";
 
 import PostList from "@/components/post/post-list";
+import { getInitialPosts } from "@/service/postService";
 
-export default function Home() {
+export default async function Home() {
+  const posts = await getInitialPosts();
   return (
     <main className="flex flex-col gap-4">
       <div className="w-full h-96 bg-underline"></div>

--- a/src/app/(tab)/posts/[id]/actions.ts
+++ b/src/app/(tab)/posts/[id]/actions.ts
@@ -1,0 +1,86 @@
+"use server";
+
+import { revalidateTag } from "next/cache";
+
+import { commentSchema } from "@/lib/schema";
+import db from "@/lib/server/db";
+import { getSession } from "@/lib/server/session";
+import { ROUTE_PATHS } from "@/constants/routePath";
+import { redirect } from "next/navigation";
+
+export const likePost = async (postId: number) => {
+  const session = await getSession();
+  try {
+    await db.like.create({
+      data: {
+        userId: session.id!,
+        postId,
+      },
+    });
+    revalidateTag(`like-status-${postId}`);
+  } catch (error) {}
+};
+
+export const dislikePost = async (postId: number) => {
+  const session = await getSession();
+  try {
+    await db.like.delete({
+      where: {
+        id: { userId: session.id!, postId },
+      },
+    });
+    revalidateTag(`like-status-${postId}`);
+  } catch (error) {}
+};
+
+export const addPostComment = async (formData: FormData) => {
+  const text = formData.get("text");
+  const postId = formData.get("postId");
+  const result = commentSchema.safeParse(text);
+
+  if (!result.success) {
+    return result.error.flatten();
+  }
+  const session = await getSession();
+  try {
+    if (session.id) {
+      await db.comment.create({
+        data: {
+          userId: session.id,
+          postId: Number(postId),
+          text: result.data,
+        },
+      });
+    }
+  } catch (error) {}
+  revalidateTag(`post-comments-${postId}`);
+};
+export const deleteComment = async (commentId: number, postId: number) => {
+  const session = await getSession();
+  try {
+    if (session.id) {
+      await db.comment.delete({
+        where: {
+          id: commentId,
+          userId: session.id,
+        },
+      });
+    }
+  } catch (error) {}
+  revalidateTag(`post-comments-${postId}`);
+};
+
+export const deletePost = async (formData: FormData) => {
+  const postId = Number(formData.get("id"));
+  const session = await getSession();
+
+  if (session.id) {
+    await db.post.delete({
+      where: {
+        id: postId,
+        userId: session.id,
+      },
+    });
+  }
+  redirect(ROUTE_PATHS.POSTS);
+};

--- a/src/app/(tab)/posts/[id]/page.tsx
+++ b/src/app/(tab)/posts/[id]/page.tsx
@@ -1,36 +1,161 @@
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { Prisma } from "@prisma/client";
+import { unstable_cache } from "next/cache";
+
+import db from "@/lib/server/db";
+import DeleteButton from "@/components/common/delete-button";
 import AIComment from "@/components/post/ai-comment";
 import Comment from "@/components/post/comment";
-import UserImage from "@/components/user/user-image";
-import { EyeIcon, HeartIcon } from "@heroicons/react/24/solid";
+import LikeButton from "@/components/post/like-button";
+import UserDefaultImage from "@/components/user/user-default-image";
+import { CATEGORIES } from "@/constants/cateogries";
+import { formatToTimeAgo } from "@/lib/client/utils";
+import { getSession } from "@/lib/server/session";
+import { getUserInfoBySession } from "@/service/userService";
+import { EyeIcon } from "@heroicons/react/24/solid";
+import { deletePost } from "./actions";
 
-export default function DetailPost({ params }: { params: { id: string } }) {
+export async function generateMetadata({ params }: { params: { id: string } }) {
+  const product = await getPost(Number(params.id));
+  return {
+    title: product?.description.slice(0, 10),
+  };
+}
+
+async function getPost(id: number) {
+  const post = await db.post.update({
+    where: {
+      id,
+    },
+    data: {
+      views: {
+        increment: 1,
+      },
+    },
+    include: {
+      _count: {
+        select: {
+          comments: true,
+        },
+      },
+      user: {
+        select: {
+          username: true,
+          avatar: true,
+        },
+      },
+    },
+  });
+  return post;
+}
+async function getLikeStatus(postId: number, userId: number) {
+  const like = await db.like.findUnique({
+    where: {
+      id: {
+        userId,
+        postId,
+      },
+    },
+  });
+  const likeCount = await db.like.count({
+    where: {
+      postId,
+    },
+  });
+  return {
+    isLiked: Boolean(like),
+    likeCount,
+  };
+}
+
+async function getInitialComments(postId: number, userId: number) {
+  const comments = await db.comment.findMany({
+    where: {
+      postId,
+    },
+    select: {
+      id: true,
+      text: true,
+      created_at: true,
+      user: {
+        select: {
+          id: true,
+          username: true,
+        },
+      },
+    },
+  });
+  return comments.map((comment) => ({ ...comment, isAuthor: comment.user.id === userId }));
+}
+export type InitialComments = Prisma.PromiseReturnType<typeof getInitialComments>;
+
+function getCachedPostDetail(postId: number) {
+  const cachedPostDetail = unstable_cache(getPost, ["post-detail"], {
+    tags: [`like-detail-${postId}`],
+  });
+  return cachedPostDetail(postId);
+}
+
+async function getCachedLikeStatus(postId: number) {
+  const session = await getSession();
+  const cachedLikeStatus = unstable_cache(getLikeStatus, ["post-like-status"], {
+    tags: [`like-status-${postId}`],
+  });
+  return cachedLikeStatus(postId, session.id!);
+}
+
+async function getCachedComments(postId: number) {
+  const session = await getSession();
+  const cachedComments = unstable_cache(getInitialComments, ["post-comments"], {
+    tags: [`post-comments-${postId}`],
+  });
+  return cachedComments(postId, session.id!);
+}
+
+async function getIsAuthor(userId: number) {
+  const session = await getSession();
+  if (session.id) return session.id === userId;
+
+  return false;
+}
+export default async function DetailPost({ params }: { params: { id: string } }) {
+  const id = Number(params.id);
+  if (isNaN(id)) return notFound();
+  const loggedInUser = await getUserInfoBySession();
+  const post = await getCachedPostDetail(id);
+  const comments = await getCachedComments(id);
+  if (!post) return notFound();
+  const isAuthor = await getIsAuthor(post.userId);
+  const { isLiked, likeCount } = await getCachedLikeStatus(id);
+
   return (
     <div className="w-full">
       <div className="p-5 flex items-center gap-3  justify-between">
-        <UserImage />
-        <span className="chip w-10 h-4 text-xs">운동</span>
+        <div className="flex items-center gap-4">
+          <UserDefaultImage avatar={post.user.avatar} username={post.user.username} width={44} height={44} />
+          <span>{post.user.username}</span>
+        </div>
+        <span className="chip w-10 h-4 text-xs">{CATEGORIES[post.category]}</span>
+        {isAuthor ? <DeleteButton isAuthor={isAuthor} id={post.id} onDelete={deletePost} /> : null}
       </div>
-      <div className="relative w-4/5 aspect-square max-h-96 mx-auto bg-underline "></div>
+      <div className="relative w-4/5 aspect-square max-h-96 mx-auto ">
+        <Image className="object-cover" priority fill src={`${post.photo}/public`} alt={post.description} />
+      </div>
       <div className="p-5 flex flex-col gap-6">
-        <p>
-          왜 갈수록 체력이 줄어드는거 같은기분ㅋㅋ 5분뛰고 힘들어서 천천히 뛰었더니 8주동안 제일 느리게 뛰었네요. 그래도
-          20분 포기 안했다. 한 잔 해~
-        </p>
+        <p>{post.description}</p>
         <div className="flex gap-5 items-start justify-between">
           <div className="flex gap-2">
-            <div className="flex items-center gap-2 text-neutral-400 text-sm">
-              <HeartIcon className="size-6" />
-              <span>0</span>
-            </div>
+            <LikeButton isLiked={isLiked} likeCount={likeCount} postId={id} />
             <div className="flex items-center gap-2 text-neutral-400 text-sm">
               <EyeIcon className="size-6 text-underline" />
-              <span>0</span>
+              <span>{post.views}</span>
             </div>
           </div>
-          <span className="text-underline">3월 20일(수) 13:00</span>
+          <span className="text-underline">{formatToTimeAgo(post.created_at.toString())}</span>
         </div>
-        <AIComment />
-        <Comment />
+        <AIComment postId={post.id} />
+        <Comment initialComments={comments} postId={post.id} loggedInUsername={loggedInUser.username} />
       </div>
     </div>
   );

--- a/src/app/(tab)/posts/actions.ts
+++ b/src/app/(tab)/posts/actions.ts
@@ -1,0 +1,39 @@
+"use server";
+
+import { LIMIT_NUMBER } from "@/constants/posts";
+import db from "@/lib/server/db";
+import { Prisma } from "@prisma/client";
+
+export async function getPaginatedPosts(cursorId: number | null) {
+  const posts = await db.post.findMany({
+    include: {
+      _count: {
+        select: {
+          comments: true,
+          likes: true,
+        },
+      },
+      user: true,
+      aiComments: {
+        include: {
+          aiBot: true,
+        },
+      },
+    },
+    skip: cursorId ? 1 : 0,
+    take: LIMIT_NUMBER + 1,
+    cursor: cursorId ? { id: cursorId } : undefined,
+    orderBy: {
+      created_at: "desc",
+    },
+  });
+  const hasMore = posts.length > LIMIT_NUMBER;
+  if (hasMore) {
+    posts.pop();
+  }
+  const isLastPage = !hasMore;
+  const nextCursorId = posts.at(-1)?.id ?? null;
+  return { items: posts, isLastPage, nextCursorId };
+}
+
+export type PaginatedPosts = Prisma.PromiseReturnType<typeof getPaginatedPosts>;

--- a/src/app/(tab)/posts/page.tsx
+++ b/src/app/(tab)/posts/page.tsx
@@ -1,10 +1,13 @@
-import PostList from "@/components/post/post-list";
+import InfinitePostList from "@/components/post/infinite-post-list";
+import { getInitialPosts } from "@/service/postService";
 
-export default function PostListPage() {
+export default async function PostListPage() {
+  const posts = await getInitialPosts();
+  const initialCursorId = posts.at(-1)?.id || null;
   return (
-    <div>
+    <div className="pb-10">
       <h3 className="font-extrabold text-md pb-2">최근 다미가 응원한 인증</h3>
-      <PostList />
+      <InfinitePostList initialPosts={posts} initialCursorId={initialCursorId} />
     </div>
   );
 }

--- a/src/app/(tab)/posts/page.tsx
+++ b/src/app/(tab)/posts/page.tsx
@@ -2,12 +2,11 @@ import InfinitePostList from "@/components/post/infinite-post-list";
 import { getInitialPosts } from "@/service/postService";
 
 export default async function PostListPage() {
-  const posts = await getInitialPosts();
-  const initialCursorId = posts.at(-1)?.id || null;
+  const { items: posts, cursorId } = await getInitialPosts();
   return (
     <div className="pb-10">
       <h3 className="font-extrabold text-md pb-2">최근 다미가 응원한 인증</h3>
-      <InfinitePostList initialPosts={posts} initialCursorId={initialCursorId} />
+      <InfinitePostList initialPosts={posts} initialCursorId={cursorId} />
     </div>
   );
 }

--- a/src/app/(tab)/search/page.tsx
+++ b/src/app/(tab)/search/page.tsx
@@ -1,11 +1,9 @@
-import PostList from "@/components/post/post-list";
 import SearchForm from "@/components/post/search-form";
 
 export default function SearchPage() {
   return (
     <div className="flex flex-col">
       <SearchForm />
-      <PostList />
     </div>
   );
 }

--- a/src/app/(tab)/users/[username]/page.tsx
+++ b/src/app/(tab)/users/[username]/page.tsx
@@ -24,9 +24,7 @@ export default async function ProfilePage({ params }: { params: { username: stri
         </p>
       </div>
       <StatusCard />
-      <div className="p-5 flex flex-col gap-5">
-        <PostList />
-      </div>
+      <div className="p-5 flex flex-col gap-5">{/* <PostList /> */}</div>
     </main>
   );
 }

--- a/src/components/common/delete-button.tsx
+++ b/src/components/common/delete-button.tsx
@@ -1,0 +1,28 @@
+import { XMarkIcon } from "@heroicons/react/24/solid";
+
+export default function DeleteButton({
+  onDelete,
+  isAuthor,
+  id,
+}: {
+  onDelete: (formData: FormData) => void;
+  isAuthor: boolean;
+  id: number;
+}) {
+  return (
+    <>
+      {isAuthor ? (
+        <form
+          action={onDelete}
+          className="ml-auto bg-secondary rounded-full aspect-square h-full max-w-10 w-full flex justify-center items-center">
+          <input type="hidden" name="id" value={id} />
+          <button>
+            <XMarkIcon className="size-5 text-neutral" />
+          </button>
+        </form>
+      ) : (
+        <div className="aspect-square h-full max-w-10 w-full"></div>
+      )}
+    </>
+  );
+}

--- a/src/components/post/ai-comment.tsx
+++ b/src/components/post/ai-comment.tsx
@@ -1,13 +1,80 @@
-export default function AIComment() {
+"use client";
+
+import { supabase } from "@/lib/server/supabaseClient";
+
+import { useEffect, useState } from "react";
+import UserDefaultImage from "../user/user-default-image";
+import { AiComment } from "@prisma/client";
+
+interface InitialAiComment {
+  text: string;
+  AiBot: { name: string; avatar: string } | { name: string; avatar: string }[];
+}
+
+export default function AIComment({ postId }: { postId: number }) {
+  const [aiComment, setAiComment] = useState<InitialAiComment | null>(null);
+
+  useEffect(() => {
+    const fetchInitialComment = async () => {
+      const { data, error } = await supabase
+        .from("AiComment")
+        .select("text, AiBot(name, avatar)")
+        .eq("postId", postId)
+        .single();
+
+      if (error) {
+        console.error("Error fetching comment:", error);
+      } else {
+        setAiComment(data);
+      }
+    };
+    fetchInitialComment();
+
+    const channel = supabase
+      .channel("ai-comment")
+      .on(
+        "postgres_changes",
+        { event: "INSERT", schema: "public", table: "AiComment", filter: `postId=eq.${postId}` },
+        async (payload: { new: AiComment }) => {
+          console.log("Received payload:", payload);
+          supabase.removeChannel(channel);
+          const newAiComment = payload.new;
+
+          const { data: aiBotData, error: aiBotError } = await supabase
+            .from("AiBot")
+            .select("name, avatar")
+            .eq("id", newAiComment.aiBotId)
+            .single();
+
+          if (aiBotError || !aiBotData) {
+            console.error("Error fetching AiBot data:", aiBotError);
+            return;
+          }
+          setAiComment({ text: payload.new.text, AiBot: { name: aiBotData?.name, avatar: aiBotData?.avatar } });
+        }
+      )
+      .subscribe((status) => {
+        if (status !== "SUBSCRIBED") {
+          console.error("Subscription failed:", status);
+        }
+      });
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [postId]);
+
+  if (aiComment === null) {
+    return <div>Loading</div>;
+  }
+  const aiBotName = Array.isArray(aiComment.AiBot) ? aiComment.AiBot[0].name : aiComment.AiBot.name;
+  const aiBotAvatar = Array.isArray(aiComment.AiBot) ? aiComment.AiBot[0].avatar : aiComment.AiBot.avatar;
   return (
     <div className="flex justify-between gap-5">
-      <p className="text-secondary-1">
-        와, 정말 대단하세요! 비록 힘들었더라도 20분 동안 포기하지 않고 뛰신 거, 정말 멋져요! 🌟와, 정말 대단하세요! 비록
-        힘들었더라도 20분 동안 포기하지 않고 뛰신 거, 정말 멋져요! 🌟..
-      </p>
+      <p className="text-secondary-1">{aiComment.text}</p>
       <div className="flex flex-col items-center">
-        <div className="bg-underline min-w-[70px] w-[70px] h-[70px] rounded-full"> </div>
-        <span>담이</span>
+        <UserDefaultImage username={aiBotName} avatar={aiBotAvatar} />
+        <span>{aiBotName}</span>
       </div>
     </div>
   );

--- a/src/components/post/comment.tsx
+++ b/src/components/post/comment.tsx
@@ -1,61 +1,92 @@
-import { ChatBubbleBottomCenterTextIcon, XMarkIcon } from "@heroicons/react/24/solid";
+"use client";
 
-const comments = [
-  {
-    id: 1,
-    text: "댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글",
-    isAuthor: true,
-    user: {
-      username: "댓글이름",
-    },
-  },
-  {
-    id: 2,
-    text: "댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글",
-    isAuthor: false,
-    user: {
-      username: "댓글이름",
-    },
-  },
-];
+import { useOptimistic } from "react";
+import { ChatBubbleBottomCenterTextIcon } from "@heroicons/react/24/solid";
 
-export default function Comment() {
+import { addPostComment, deleteComment } from "@/app/(tab)/posts/[id]/actions";
+import { InitialComments } from "@/app/(tab)/posts/[id]/page";
+import { commentSchema } from "@/lib/schema";
+import DeleteButton from "../common/delete-button";
+
+type CommentOptimisticValue =
+  | {
+      action: "add";
+      newComment: string;
+    }
+  | { action: "delete"; commentId: number };
+
+export default function Comments({
+  initialComments,
+  postId,
+  loggedInUsername,
+}: {
+  initialComments: InitialComments;
+  postId: number;
+  loggedInUsername: string;
+}) {
+  const [comments, reducer] = useOptimistic(
+    initialComments,
+    (previousComments, commentOptimisticValue: CommentOptimisticValue) => {
+      if (commentOptimisticValue.action === "add") {
+        return [
+          ...previousComments,
+          {
+            id: new Date().getDate(),
+            text: commentOptimisticValue.newComment,
+            created_at: new Date(),
+            postId,
+            user: { username: loggedInUsername, id: 0 },
+            isAuthor: true,
+          },
+        ];
+      }
+
+      return previousComments.filter((comment) => comment.id !== commentOptimisticValue.commentId);
+    }
+  );
+
+  const handleUploadComment = (formData: FormData) => {
+    const result = commentSchema.safeParse(formData.get("text"));
+    if (result.success) {
+      reducer({ action: "add", newComment: result.data });
+      addPostComment(formData);
+    }
+  };
+  const handleDeleteComment = (formData: FormData) => {
+    const commentId = Number(formData.get("id"));
+    reducer({ action: "delete", commentId });
+    deleteComment(commentId, postId);
+  };
+
   return (
     <div>
-      <form className="flex w-full gap-2 comment-form ">
+      <form action={handleUploadComment} className="flex w-full gap-2 comment-form ">
         <div className="flex relative w-full ">
           <label className="absolute -translate-y-1/2 top-1/2 left-3">
             <ChatBubbleBottomCenterTextIcon className="size-6 text-underline " />
           </label>
           <input
-            className="bg-transparent h-11 pl-12 w-full text-underline  border-b border-underline focus:outline-none focus:ring focus:ring-secondary placeholder:text-underline"
+            className="bg-transparent h-11 pl-12 w-full border-b border-underline focus:outline-none focus:ring focus:ring-secondary placeholder:text-underline"
             name="text"
             type="text"
             required
             placeholder="코멘트를 입력해주세요."
           />
         </div>
-        <input type="hidden" name="tweetId" value="tweetId" />
+        <input type="hidden" name="postId" value={postId} />
         <button className="primary-button min-w-16">추가</button>
       </form>
       {comments.map((comment) => (
         <div key={comment.id} className="*:text-md flex items-center my-3">
           <span className="font-semibold w-3/12 min-w-16">{comment.user.username}</span>
-          <div className="flex flex-col gap-1">
-            <div className="flex gap-2">
-              <span> {comment.text}</span>
-              {comment.isAuthor ? (
-                <form className="ml-auto bg-secondary rounded-full aspect-square h-full max-w-10 w-full flex justify-center items-center">
-                  <input type="hidden" name="commentId" value={comment.id} />
-                  <button>
-                    <XMarkIcon className="size-5 text-neutral" />
-                  </button>
-                </form>
-              ) : (
-                <div className="aspect-square h-full max-w-10 w-full"></div>
-              )}
+          <div className="flex flex-col gap-1 w-full">
+            <div className="flex gap-2 items-center">
+              <span className="items-center"> {comment.text}</span>
+              <div className="ml-auto flex flex-col min-w-10 gap-1">
+                <DeleteButton onDelete={handleDeleteComment} id={comment.id} isAuthor={comment.isAuthor} />
+                <span className=" text-underline text-xs">10일 전</span>
+              </div>
             </div>
-            <span className=" self-end text-underline text-xs mr-3">10일 전</span>
           </div>
         </div>
       ))}

--- a/src/components/post/infinite-post-list.tsx
+++ b/src/components/post/infinite-post-list.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { InitialPosts } from "@/service/postService";
+import ListPost from "./list-post";
+import { getPaginatedPosts } from "@/app/(tab)/posts/actions";
+import useInfiniteScroll from "@/hooks/useInfiniteScroll";
+
+export default function InfinitePostList({
+  initialPosts,
+  initialCursorId,
+}: {
+  initialPosts: InitialPosts;
+  initialCursorId: number | null;
+}) {
+  const {
+    items: posts,
+    isLoading,
+    triggerRef,
+  } = useInfiniteScroll({ initialItems: initialPosts, fetchMoreItems: getPaginatedPosts, initialCursorId });
+  return (
+    <div className="flex flex-col gap-4">
+      {posts.map((post, i) => (
+        <ListPost key={post.id} {...post} />
+      ))}
+      <div ref={triggerRef}>{isLoading ? "로딩 중" : null}</div>
+    </div>
+  );
+}

--- a/src/components/post/infinite-post-list.tsx
+++ b/src/components/post/infinite-post-list.tsx
@@ -9,7 +9,7 @@ export default function InfinitePostList({
   initialPosts,
   initialCursorId,
 }: {
-  initialPosts: InitialPosts;
+  initialPosts: InitialPosts["items"];
   initialCursorId: number | null;
 }) {
   const {

--- a/src/components/post/like-button.tsx
+++ b/src/components/post/like-button.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useOptimistic } from "react";
+import { HeartIcon } from "@heroicons/react/24/solid";
+import { HeartIcon as OutlineHandHeartIcon } from "@heroicons/react/24/outline";
+
+import { dislikePost, likePost } from "@/app/(tab)/posts/[id]/actions";
+
+export default function LikeButton({
+  isLiked,
+  likeCount,
+  postId,
+}: {
+  isLiked: boolean;
+  likeCount: number;
+  postId: number;
+}) {
+  const [state, reducer] = useOptimistic({ likeCount, isLiked }, (previousState, _) => ({
+    likeCount: previousState.isLiked ? previousState.likeCount - 1 : previousState.likeCount + 1,
+    isLiked: !previousState.isLiked,
+  }));
+
+  const handleLikeButton = () => {
+    reducer(null);
+    if (isLiked) {
+      dislikePost(postId);
+    } else {
+      likePost(postId);
+    }
+  };
+
+  return (
+    <form action={handleLikeButton}>
+      <button className={"flex items-center gap-2 text-neutral-400 text-sm transition-colors"}>
+        {state.isLiked ? (
+          <HeartIcon className="size-6 text-primary hover:text-primary-1" />
+        ) : (
+          <OutlineHandHeartIcon className="size-6 text-neutral hover:text-stone-300" />
+        )}
+        <span> {state.likeCount}</span>
+      </button>
+    </form>
+  );
+}

--- a/src/components/post/list-post.tsx
+++ b/src/components/post/list-post.tsx
@@ -1,28 +1,34 @@
 import Link from "next/link";
 
-export default function ListPost() {
+import { PaginatedPosts } from "@/app/(tab)/posts/actions";
+import { CATEGORIES } from "@/constants/cateogries";
+import { formatToTimeAgo } from "@/lib/client/utils";
+import UserDefaultImage from "../user/user-default-image";
+
+type PostProps = PaginatedPosts["items"][number];
+
+export default function ListPost({ id, description, created_at, category, user, aiComments }: PostProps) {
   return (
     <Link
-      href={"/posts/1"}
+      href={`/posts/${id}`}
       className="text-neutral flex flex-col items-center px-5 py-4 shadow-custom rounded-2xl *:w-full gap-3">
       <div className="flex justify-between">
-        <span>3월 20일 (수) 13:00</span>
-        <div className="chip w-10 h-4 text-xs">운동</div>
+        <span>{formatToTimeAgo(created_at.toString())}</span>
+        <div className="chip w-10 h-4 text-xs">{CATEGORIES[category]}</div>
       </div>
-      <div className="flex flex-col gap-3 items-center">
+      <div className="flex flex-col gap-3 items-center *:w-full">
         <div className="flex gap-3 justify-between items-center">
-          <p className="multiline-ellipsis text-sm">
-            왜 갈수록 체력이 줄어드는거 같은기분ㅋㅋ 5분뛰고 힘들어서 천천히 뛰었더니 8주동안 제일 느리게 뛰었네요.
-            그래도 20분 포기 안했다. 한 잔 해~
-          </p>
-          <div className="min-w-11 h-11 bg-underline rounded-full"></div>
+          <p className="multiline-ellipsis text-sm">{description}</p>
+          <UserDefaultImage avatar={user.avatar} username={user.username} width={44} height={44} />
         </div>
         <div className="flex gap-3 justify-between items-center">
-          <div className="min-w-11 h-11 bg-underline rounded-full"></div>
-          <p className="multiline-ellipsis  text-sm text-[#9C8663]">
-            와, 정말 대단하세요! 비록 힘들었더라도 20분 동안 포기하지 않고 뛰신 거, 정말 멋져요! 🌟와, 정말 대단하세요!
-            비록 힘들었더라도 20분 동안 포기하지 않고 뛰신 거, 정말 멋져요! 🌟.
-          </p>
+          <UserDefaultImage
+            avatar={aiComments[0]?.aiBot.avatar ?? null}
+            username={user.username}
+            width={44}
+            height={44}
+          />
+          <p className="multiline-ellipsis  text-sm text-[#9C8663]">{aiComments[0]?.text}</p>
         </div>
       </div>
     </Link>

--- a/src/components/post/post-list.tsx
+++ b/src/components/post/post-list.tsx
@@ -1,16 +1,11 @@
 import { InitialPosts } from "@/service/postService";
 import ListPost from "./list-post";
 
-export default function PostList({ initialPosts }: { initialPosts: InitialPosts }) {
-  console.log(initialPosts.map((test) => test));
-
+export default function PostList({ initialPosts }: { initialPosts: InitialPosts["items"] }) {
   return (
     <div className="flex flex-col gap-4">
       {initialPosts.map((post, i) => (
-        <>
-          <ListPost key={i} {...post} />
-          <div></div>
-        </>
+        <ListPost key={post.id} {...post} />
       ))}
     </div>
   );

--- a/src/components/post/post-list.tsx
+++ b/src/components/post/post-list.tsx
@@ -1,10 +1,16 @@
+import { InitialPosts } from "@/service/postService";
 import ListPost from "./list-post";
 
-export default function PostList() {
+export default function PostList({ initialPosts }: { initialPosts: InitialPosts }) {
+  console.log(initialPosts.map((test) => test));
+
   return (
     <div className="flex flex-col gap-4">
-      {[1, 2].map((_, i) => (
-        <ListPost key={i} />
+      {initialPosts.map((post, i) => (
+        <>
+          <ListPost key={i} {...post} />
+          <div></div>
+        </>
       ))}
     </div>
   );

--- a/src/components/user/user-default-image.tsx
+++ b/src/components/user/user-default-image.tsx
@@ -1,0 +1,26 @@
+import { UserIcon } from "@heroicons/react/24/solid";
+import Image from "next/image";
+
+export default function UserDefaultImage({
+  avatar,
+  username,
+  style,
+  width = 40,
+  height = 40,
+}: {
+  avatar: string | null;
+  username: string;
+  width?: number;
+  height?: number;
+  style?: string;
+}) {
+  return (
+    <div className={`rounded-full ${style}`}>
+      {avatar !== null ? (
+        <Image src={`${avatar}/avatar`} width={width} height={height} alt={username} />
+      ) : (
+        <UserIcon width={width} height={height} />
+      )}
+    </div>
+  );
+}

--- a/src/constants/posts.ts
+++ b/src/constants/posts.ts
@@ -1,0 +1,1 @@
+export const LIMIT_NUMBER = 2;

--- a/src/constants/posts.ts
+++ b/src/constants/posts.ts
@@ -1,1 +1,1 @@
-export const LIMIT_NUMBER = 2;
+export const LIMIT_NUMBER = 5;

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from "react";
+
+interface UseInfiniteScrollOptions<T> {
+  initialItems: T[];
+  fetchMoreItems: (
+    cursorId: number | null
+  ) => Promise<{ items: T[]; nextCursorId: number | null; isLastPage: boolean }>;
+  initialCursorId?: number | null;
+}
+
+function useInfiniteScroll<T>({ initialItems, fetchMoreItems, initialCursorId = null }: UseInfiniteScrollOptions<T>) {
+  const [items, setItems] = useState<T[]>(initialItems);
+  const [cursorId, setCursorId] = useState<number | null>(initialCursorId);
+  const [isLastPage, setIsLastPage] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const triggerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      async (entries, observer) => {
+        const element = entries[0];
+        if (element.isIntersecting && triggerRef.current && !isLoading && !isLastPage) {
+          observer.unobserve(triggerRef.current);
+          setIsLoading(true);
+
+          try {
+            const { items: newItems, nextCursorId, isLastPage: newIsLastPage } = await fetchMoreItems(cursorId);
+
+            setItems((prev) => [...prev, ...newItems]);
+            setCursorId(nextCursorId);
+            setIsLastPage(newIsLastPage);
+
+            if (nextCursorId && !newIsLastPage && triggerRef.current) {
+              observer.observe(triggerRef.current);
+            }
+          } catch (error) {
+            console.error("Error fetching more items:", error);
+          } finally {
+            setIsLoading(false);
+          }
+        }
+      },
+      {
+        threshold: 1.0,
+      }
+    );
+
+    if (triggerRef.current && !isLastPage && !isLoading) {
+      observer.observe(triggerRef.current);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [cursorId, isLastPage]);
+
+  return { items, isLoading, isLastPage, triggerRef };
+}
+
+export default useInfiniteScroll;

--- a/src/lib/client/utils.ts
+++ b/src/lib/client/utils.ts
@@ -1,0 +1,14 @@
+export function formatToTimeAgo(date: string): string {
+  const dayInMs = 1000 * 60 * 60 * 24;
+  const time = new Date(date).getTime();
+  const now = new Date().getTime();
+  const diff = Math.round((time - now) / dayInMs);
+
+  const formatter = new Intl.RelativeTimeFormat("ko");
+
+  return formatter.format(diff, "days");
+}
+
+export function formatToWon(price: number): string {
+  return price.toLocaleString("ko-KR");
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -92,6 +92,79 @@ export const postSchema = z.object({
   category: z.string().refine(isCategory, "잘못된 주제선택입니다."),
 });
 
+export const commentSchema = z
+  .string({
+    required_error: "코멘트 내용은 필수 값입니다.",
+  })
+  .trim()
+  .min(1, "코멘트는 빈 값이 될 수 없습니다.")
+  .max(200, "코멘트는 최대 200자 입니다.");
+
+export const keywordSchema = z
+  .string({
+    required_error: "검색어는 필수 값입니다.",
+  })
+  .trim()
+  .min(1, "검색어는 빈 값이 될 수 없습니다.")
+  .max(20, "검색어는 최대 20자 입니다.");
+
+export const profileSchema = z
+  .object({
+    email: z
+      .string({
+        required_error: "이메일은 필수 값입니다.",
+      })
+      .trim()
+      .email("이메일 형식으로 작성해주세요."),
+    username: z
+      .string({
+        invalid_type_error: "이름은 문자만 가능합니다.",
+        required_error: "이름은 필수 값입니다.",
+      })
+      .trim()
+      .min(USERNAME_MIN_LENGTH, "이름은 2글자 이상이어야 합니다."),
+    password: z.string({
+      required_error: "비밀번호는 필수 값입니다.",
+    }),
+    newPassword: z
+      .string()
+      .optional()
+      .refine((value) => !value || (value.length >= PASSWORD_MIN_LENGTH && PASSWORD_REGEX.test(value)), {
+        message: "비밀번호는 8글자 이상이어야 하며, 1개 이상의 숫자를 포함해야 합니다.",
+      }),
+    bio: z
+      .string()
+      .trim()
+      .optional()
+      .refine((value) => !value || value.length <= 200, {
+        message: "소개글은 200글자 이하이어야 합니다.",
+      }),
+  })
+  .superRefine(async ({ email }, ctx) => {
+    const isEmailAvailable = await checkEmailAvailability(email);
+    if (!isEmailAvailable) {
+      ctx.addIssue({
+        code: "custom",
+        message: "이미 존재하는 이메일입니다.",
+        path: ["email"],
+        fatal: true,
+      });
+      return z.NEVER;
+    }
+  })
+  .superRefine(async ({ username }, ctx) => {
+    const isUsernameAvailable = await checkUsernameAvailability(username);
+    if (!isUsernameAvailable) {
+      ctx.addIssue({
+        code: "custom",
+        message: "이미 존재하는 이름입니다.",
+        path: ["username"],
+        fatal: true,
+      });
+      return z.NEVER;
+    }
+  });
+
 export type CreateAccountType = z.infer<typeof accountSchema>;
 export type LogInType = z.infer<typeof logInSchema>;
 export type UploadPostType = z.infer<typeof postSchema>;

--- a/src/lib/server/supabaseClient.ts
+++ b/src/lib/server/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/lib/server/validate.ts
+++ b/src/lib/server/validate.ts
@@ -1,6 +1,8 @@
 "use server";
 
-import { getUserByEmail, getUserByUsername } from "@/service/userService";
+import { getUserAuthInfo, getUserByEmail, getUserByUsername } from "@/service/userService";
+import { getSession } from "./session";
+import bcrypt from "bcrypt";
 
 export const isUsernameExists = async (username: string) => {
   const user = await getUserByUsername(username);
@@ -11,4 +13,29 @@ export const isEmailExists = async (email: string) => {
   const user = await getUserByEmail(email);
 
   return Boolean(user);
+};
+
+export const checkEmailAvailability = async (email: string) => {
+  const session = await getSession();
+  const user = await getUserByEmail(email);
+
+  if (session.id === user?.id) return Boolean(user);
+
+  return !Boolean(user);
+};
+
+export const checkUsernameAvailability = async (username: string) => {
+  const session = await getSession();
+  const user = await getUserByUsername(username);
+
+  if (session.id === user?.id) return Boolean(user);
+
+  return !Boolean(user);
+};
+
+export const checkUserPassword = async (password: string) => {
+  const user = await getUserAuthInfo();
+  const isValidPassword = await bcrypt.compare(password, user!.password ?? "소셜로그인");
+
+  return isValidPassword;
 };

--- a/src/service/categoryService.ts
+++ b/src/service/categoryService.ts
@@ -1,0 +1,18 @@
+import db from "@/lib/server/db";
+
+export async function getMostPopularCategory() {
+  const result = await db.post.groupBy({
+    by: ["category"],
+    _count: {
+      category: true,
+    },
+    orderBy: {
+      _count: {
+        category: "desc",
+      },
+    },
+    take: 1,
+  });
+
+  return result[0].category;
+}

--- a/src/service/postService.ts
+++ b/src/service/postService.ts
@@ -1,0 +1,28 @@
+import { LIMIT_NUMBER } from "@/constants/posts";
+import db from "@/lib/server/db";
+import { Prisma } from "@prisma/client";
+
+export async function getInitialPosts() {
+  const posts = await db.post.findMany({
+    include: {
+      _count: {
+        select: {
+          comments: true,
+          likes: true,
+        },
+      },
+      user: true,
+      aiComments: {
+        include: {
+          aiBot: true,
+        },
+      },
+    },
+    take: LIMIT_NUMBER,
+    orderBy: {
+      created_at: "desc",
+    },
+  });
+  return posts;
+}
+export type InitialPosts = Prisma.PromiseReturnType<typeof getInitialPosts>;


### PR DESCRIPTION
Close #10
- 관련 깃이슈 #1 
- 사용자가 등록한 글에 대한 요청 내용에 대해 모든 로직을 개발 하였습니다.

# 트러블 슈팅
 
## 문제 발생

사용자가 게시글 등록할 때, open AI 메시지를 생성 로직이 바로 연결 된다. 
이런 경우에, 게시글 등록할 때 사용자 대기 시간 문제가 발생한다.
   1. 게시글(글/이미지)를 등록하는 시간
   2. Open AI에게 메시지를 요청하여 받아오는 시간
   3. AI 메세지를 받아온 메세지를 게시글의 코멘트로 등록하는 시간

이 문제점으로 인해 사용자는 약 10초 지연시간이 발생한다. 

### 관련 영상 
<details><summary>영상  보기</summary>
<p>
<video src='https://github.com/user-attachments/assets/f7403d42-b029-4ad7-ad0a-aa33e6dc5e66'/>
</p>
</details> 

## 해결 방법 

- [feat: open ai 로 ai comment 를 비동기로 저장](https://github.com/j2h30728/boost-pal/pull/9/commits/5e429570fd28d4de96d70acb1decbe1d158002a7)
- open AI 메시지 요청을 비동기 작업으로 요창하는 것으로 변경
- opena AI 메시지 생성 및 게시글의 AI comment로 등록될 떄까지 클라이언트에서  로딩상태를 보여주고 완료시 렌더링해주는 방법 채택

**AI comment로 등록이 되었는 가라는 서버상태, 즉 외부상태를 클라이언트에서 알 수 있어야 하는 것이 중**요하다.
이를 위하여 사용할 수 있는 기술은 폴링, 롱 폴링, SSE, 웹소켓이 존재한다.

폴링, 롱 폴링, SSE의 경우에는 지속적으로 서버와 연경을 유지하거나 주기적으로 요청을 보내야한다는 부담감과 단점이 존재한다.
서버리스 환경 배포를 진행할 예정이기 때문에 이 점도 고려한다.

아래의 비교를 통해 Supabase Realtime을 채택하기로 결정하였다.

> #### 폴링
> - 주기적으로 서버에 요청을 보내서 확인하기떄문에 서버리스 환경에서의 요금 발생 가능
> - 자주 요청을 보내야하기 때문에 서버 부하 증가 가능
> #### 롤퐁링
> - 서버가 새로운 데이터가 있을 떄까지 연결을 유지한 후 데이터를 전송하는 방식이기 떄문에 서버리스 환경과 맞지 않음
> - 지속적으로 연결확인 필요 및 끊어진 경우에는 재연결 필요
> #### SSE
> - 서버에서 클라이언트로 단방향 통신으로 실시간 이벤트 푸시하는 방식 
> - 서버에서 실시간 데이터베이스 이벤트 감지하고 클라이언트에게 전달해야하는 기능 구현 필요
>     - 서버에서 주기적으로 데이터베이스를 조회하거나 트리거를 통해 변경 사항을 감지해야하는 추가 구현 필요
> #### Supabase realtime
> - 데이터베이스의 특정 테이블을 구독하다가 이벤트가 발생하면 데이터를 받아오는 방식
> -  websoket을 통해 실시간으로 데이터를 전달 및 서버리스 환경에 적합
> - 이미 supabase를 사용하고 있으며, supabse realtime으로 특정 이벤트만 구독하는 것으로 결정


## 등록 후 바로 AI comment를 불러 오는 로직으로 변경
- 관련 코드 :  [링크](https://github.com/j2h30728/boost-pal/pull/11/files#diff-b9f121e69323eee5e652c6c382b661770dce79f35fd4420e4dcb7a821d3903ffR17-R65)
1. 사용자가 post를 등록하면 **상세페이지로 즉시 리다이렉트** 한다.
2. **AI comment가 등록될 떄까지 로딩 상태를 표시**해준다.
    - open ai로 메시지 요청을 보내고 반환된 메시지를 AI comment 테이블에 등록하는 시간이 필요하다.
3. Supabase Realtime 을 사용하여, **AI comment 테이블을 구독**한다.
    - 해당 테이블에서 INSERT 이벤트가 발생할 떄까지 구독한다.
    - 만약, AI comment가 존재하는 경우라면 구독을 하지않는다.
5. AI commen가 등록이 완료된 경우(IINSERT 이벤트 발생) **AI comment만  레린더링 시켜 사용자에게 보여준다**.

<img src='https://github.com/user-attachments/assets/c3e03a11-2b84-4d1d-94b5-50361fa829c9' width='700' />

## 구현 내용
- 글 상세 페이지 (좋아요, 댓글 낙관적 업데이트 기능)
- 카테고리별로 글을 확인할 수 있는 기능
- 커서 페이지 네이션과 Intersection Observer API를 사용하여 무한 스크롤링 구현
- Supabase realtime을 사용하여 AI comment 테이블을 등록하고 INSER 이벤트가 일어날 경우 코멘트를 가져와 렌더링 진행


## 레퍼런스
- https://www.npmjs.com/package/@supabase/supabase-js