### PR TITLE
Feature #29 cache error

### DIFF
--- a/src/app/(tab)/posts/[id]/actions.ts
+++ b/src/app/(tab)/posts/[id]/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidateTag } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 
 import { commentSchema } from "@/lib/schema";
 import db from "@/lib/server/db";
@@ -82,5 +82,6 @@ export const deletePost = async (formData: FormData) => {
       },
     });
   }
+  revalidatePath(`/posts/${postId}`);
   redirect(ROUTE_PATHS.POSTS);
 };

--- a/src/app/(tab)/posts/[id]/page.tsx
+++ b/src/app/(tab)/posts/[id]/page.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { notFound } from "next/navigation";
 import { Prisma } from "@prisma/client";
 import { unstable_cache } from "next/cache";
+import { EyeIcon } from "@heroicons/react/24/solid";
 
 import db from "@/lib/server/db";
 import DeleteButton from "@/components/common/delete-button";
@@ -13,8 +14,8 @@ import { CATEGORIES } from "@/constants/cateogries";
 import { formatToTimeAgo } from "@/lib/client/utils";
 import { getSession } from "@/lib/server/session";
 import { getUserInfoBySession } from "@/service/userService";
-import { EyeIcon } from "@heroicons/react/24/solid";
 import { deletePost } from "./actions";
+import { cacheTags } from "@/lib/cacheTags";
 
 export async function generateMetadata({ params }: { params: { id: string } }) {
   const product = await getPost(Number(params.id));
@@ -92,7 +93,7 @@ export type InitialComments = Prisma.PromiseReturnType<typeof getInitialComments
 
 function getCachedPostDetail(postId: number) {
   const cachedPostDetail = unstable_cache(getPost, ["post-detail"], {
-    tags: [`post-detail-${postId}`, `user-profile`],
+    tags: cacheTags.postDetail(postId),
   });
   return cachedPostDetail(postId);
 }
@@ -100,7 +101,7 @@ function getCachedPostDetail(postId: number) {
 async function getCachedLikeStatus(postId: number) {
   const session = await getSession();
   const cachedLikeStatus = unstable_cache(getLikeStatus, ["post-like-status"], {
-    tags: [`like-status-${postId}`],
+    tags: [cacheTags.postLike(postId)],
   });
   return cachedLikeStatus(postId, session.id!);
 }
@@ -108,7 +109,7 @@ async function getCachedLikeStatus(postId: number) {
 async function getCachedComments(postId: number) {
   const session = await getSession();
   const cachedComments = unstable_cache(getInitialComments, ["post-comments"], {
-    tags: [`post-comments-${postId}`],
+    tags: [cacheTags.postComment(postId)],
   });
   return cachedComments(postId, session.id!);
 }

--- a/src/app/(tab)/posts/[id]/page.tsx
+++ b/src/app/(tab)/posts/[id]/page.tsx
@@ -92,7 +92,7 @@ export type InitialComments = Prisma.PromiseReturnType<typeof getInitialComments
 
 function getCachedPostDetail(postId: number) {
   const cachedPostDetail = unstable_cache(getPost, ["post-detail"], {
-    tags: [`like-detail-${postId}`],
+    tags: [`post-detail-${postId}`, `user-profile`],
   });
   return cachedPostDetail(postId);
 }

--- a/src/app/(tab)/users/[username]/edit/actions.ts
+++ b/src/app/(tab)/users/[username]/edit/actions.ts
@@ -1,15 +1,16 @@
 "use server";
 
+import { revalidateTag } from "next/cache";
+import bcrypt from "bcrypt";
+import { redirect } from "next/navigation";
+
 import db from "@/lib/server/db";
 import { profileSchema } from "@/lib/schema";
 import { getSession } from "@/lib/server/session";
 import { checkEmailAvailability, checkUsernameAvailability, checkUserPassword } from "@/lib/server/validate";
 import { getUserAuthInfo, getUserInfoBySession } from "@/service/userService";
-
-import bcrypt from "bcrypt";
-import { redirect } from "next/navigation";
 import { PASSWORD_ERROR_MESSAGE, USER_INFO_ERROR_MESSAGE } from "@/constants/messages";
-import { revalidateTag } from "next/cache";
+import { cacheTags } from "@/lib/cacheTags";
 
 export async function editProfile(formData: FormData) {
   const data = {
@@ -69,7 +70,7 @@ export async function editProfile(formData: FormData) {
     }
     return String(error);
   }
-  revalidateTag("user-profile");
+  revalidateTag(cacheTags.profile);
   const user = await getUserInfoBySession();
   redirect(`/users/${user.username}`);
 }

--- a/src/app/(tab)/users/[username]/edit/actions.ts
+++ b/src/app/(tab)/users/[username]/edit/actions.ts
@@ -9,6 +9,7 @@ import { getUserAuthInfo, getUserInfoBySession } from "@/service/userService";
 import bcrypt from "bcrypt";
 import { redirect } from "next/navigation";
 import { PASSWORD_ERROR_MESSAGE, USER_INFO_ERROR_MESSAGE } from "@/constants/messages";
+import { revalidateTag } from "next/cache";
 
 export async function editProfile(formData: FormData) {
   const data = {
@@ -68,7 +69,7 @@ export async function editProfile(formData: FormData) {
     }
     return String(error);
   }
-
+  revalidateTag("user-profile");
   const user = await getUserInfoBySession();
   redirect(`/users/${user.username}`);
 }

--- a/src/lib/cacheTags.ts
+++ b/src/lib/cacheTags.ts
@@ -1,0 +1,6 @@
+export const cacheTags = {
+  profile: "user-profile" as const,
+  postDetail: (postId: number) => [`post-detail-${postId}`, cacheTags.profile],
+  postLike: (postId: number) => `like-status-${postId}` as const,
+  postComment: (postId: number) => `post-comments-${postId}` as const,
+};


### PR DESCRIPTION
# 트러블 슈팅

Close #28  
## 이슈

글 상세페이지의 상세 데이터(사용자 이미지, 이름, 이미지, 글)가 데이터베이스 값이 아닌 캐싱된 값으로 계속적으로 렌더링

## 해결

### 1. 배포 환경에서의 캐싱 데이터 제거
이미 배포환경에서 캐싱된 데이터를 제거하기 위해서 *Vercel > Setting > Data Cache > Purge everything* 작업을 진행한다.
이로써, 배포환경에서 이미 캐싱되어있던 데이터를 삭제하고 데이터베이스와 일치하는 데이터를 렌더링한다.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/1b6ad849-d5d4-4763-b118-3f044e1b6dae">

이 문제점은, next.js가 배포될 경우 CDN을 통해 캐싱이 따로 저장되기 떄문에 발생하는 문제이다.
그렇기 때문에 캐싱과 재검증 전략을 바꿔야할 필요가 있다.

### 2. revalidate tags 추가 및 cacheKeys로 함께 관리

글을 조회할때마다 조회수가 올라가는 로직이기 때문에, 글 상세 데이터를 캐싱하지않는 방법은 현재상황에서는 어렵다.

그래서 글을 캐시하는 캐시태그에 트리거를 걸어 글 상세 데이터를 원본데이터와 일치시킨다.
- **추가된 캐시태그 및 revalidate**
    - 상세 글 : [`post-detail-${postId}`,: 'user-profile'] 
    - 사용자 정보수정 완료 : `revalidate("user-profile")`
    - 글 삭제 : : `revalidatePath("/posts/${postId}")`


## 추가사항

- AWS SQS, Lambda 의 서버가 미국으로 설정되어있었기 떄문에 한국-서울로 변경작업한다.

## 레퍼런스
