### PR TITLE
Feature #19 calendar

### DIFF
--- a/src/app/(tab)/calendar/actions.tsx
+++ b/src/app/(tab)/calendar/actions.tsx
@@ -1,0 +1,21 @@
+"use server";
+
+import db from "@/lib/server/db";
+import { getSession } from "@/lib/server/session";
+import { groupPostsByDate } from "@/lib/utils";
+
+export const getWrittenPostByYearnAndMonth = async (year: number, month: number) => {
+  const startDateOfMonth = new Date(year, month - 1, 1);
+  const endDateOfMonth = new Date(year, month, 0);
+  const session = await getSession();
+  const posts = await db.post.findMany({
+    where: {
+      userId: session.id!,
+      created_at: {
+        gte: startDateOfMonth,
+        lt: endDateOfMonth,
+      },
+    },
+  });
+  return groupPostsByDate(posts);
+};

--- a/src/app/(tab)/layout.tsx
+++ b/src/app/(tab)/layout.tsx
@@ -10,7 +10,7 @@ export default async function RootLayout({
   const user = await getUserInfoBySession();
 
   return (
-    <div className="relative pb-[40px]">
+    <div className="relative pb-[100px]">
       <HeaderLayout>{children}</HeaderLayout>
       <TabBar username={encodeURI(user.username)} />
     </div>

--- a/src/components/calendar/calendar-body.tsx
+++ b/src/components/calendar/calendar-body.tsx
@@ -6,14 +6,14 @@ import useCalendarContext from "./useCalendarContext";
 const CalendarBody = () => {
   const {
     calendar: { daysInMonth, selectedDate, currentDate },
-    posts,
+    posts: { data },
   } = useCalendarContext();
   const today = new Date();
   const isToday = (year: number, month: number, date: number) =>
     today.getFullYear() === year && today.getDate() === date && today.getMonth() + 1 === month;
 
   return (
-    <div className="flex flex-col gap-4 bg-white p-1 rounded-2xl min-w-72">
+    <div className="flex flex-col gap-4 bg-white p-2 rounded-2xl min-w-72">
       <div className="grid grid-cols-7 gap-4">
         {WEEKS.map((week, index) => (
           <div className={`flex justify-center size-10 text-gray-700"`} key={week}>
@@ -23,7 +23,7 @@ const CalendarBody = () => {
       </div>
       <div className="grid grid-cols-7 gap-4">
         {daysInMonth.map((date) => {
-          const savePostDate = posts.find((post) => post.date === date.date);
+          const savePostDate = data.find((post) => post.date === date.date);
           return (
             <div
               onClick={savePostDate?.date === date.date ? () => selectedDate.selectDate(date.date) : () => {}}

--- a/src/components/calendar/calendar-body.tsx
+++ b/src/components/calendar/calendar-body.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import { WEEKS } from "@/constants/calendar";
 import useCalendarContext from "./useCalendarContext";
 
 const CalendarBody = () => {
-  const weeks = ["일", "월", "화", "수", "목", "금", "토"];
-  const { daysInMonth, selectedDate, currentDate } = useCalendarContext();
+  const {
+    calendar: { daysInMonth, selectedDate, currentDate },
+    posts,
+  } = useCalendarContext();
   const today = new Date();
   const isToday = (year: number, month: number, date: number) =>
     today.getFullYear() === year && today.getDate() === date && today.getMonth() + 1 === month;
@@ -12,30 +15,33 @@ const CalendarBody = () => {
   return (
     <div className="flex flex-col gap-4 bg-white p-1 rounded-2xl min-w-72">
       <div className="grid grid-cols-7 gap-4">
-        {weeks.map((week, index) => (
+        {WEEKS.map((week, index) => (
           <div className={`flex justify-center size-10 text-gray-700"`} key={week}>
             {week}
           </div>
         ))}
       </div>
       <div className="grid grid-cols-7 gap-4">
-        {daysInMonth.map((date) => (
-          <div
-            onClick={() => selectedDate.selectDate(date.date)}
-            key={date.date}
-            className={`flex flex-col justify-center items-center cursor-pointer size-10
-              ${currentDate.month !== date.month ? "invisible" : "visible"}
-              ${
-                isToday(+date.year, +date.month, +date.day)
-                  ? "min-w-8 min-h-8 bg-secondary bg-opacity-30 rounded-full"
-                  : ""
-              }
-              ${selectedDate.date === date.date ? "min-w-8 min-h-8 bg-primary bg-opacity-30 rounded-full" : ""}
-              `}>
-            {date.day}
-            {isToday(+date.year, +date.month, +date.day) && <small className="text-base text-xs">오늘</small>}
-          </div>
-        ))}
+        {daysInMonth.map((date) => {
+          const savePostDate = posts.find((post) => post.date === date.date);
+          return (
+            <div
+              onClick={savePostDate?.date === date.date ? () => selectedDate.selectDate(date.date) : () => {}}
+              key={date.date}
+              className={`flex flex-col justify-center items-center cursor-pointer size-10
+                ${currentDate.month !== date.month ? "invisible" : "visible"}
+                ${
+                  isToday(+date.year, +date.month, +date.day)
+                    ? "min-w-8 min-h-8 bg-secondary bg-opacity-30 rounded-full"
+                    : ""
+                }
+                ${savePostDate?.date === date.date ? "min-w-8 min-h-8 bg-primary bg-opacity-30 rounded-full" : ""}
+                `}>
+              {date.day}
+              {isToday(+date.year, +date.month, +date.day) && <small className="text-base text-xs">오늘</small>}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/calendar/calendar-body.tsx
+++ b/src/components/calendar/calendar-body.tsx
@@ -28,14 +28,19 @@ const CalendarBody = () => {
             <div
               onClick={savePostDate?.date === date.date ? () => selectedDate.selectDate(date.date) : () => {}}
               key={date.date}
-              className={`flex flex-col justify-center items-center cursor-pointer size-10
+              className={`flex flex-col justify-center items-center size-10
                 ${currentDate.month !== date.month ? "invisible" : "visible"}
                 ${
                   isToday(+date.year, +date.month, +date.day)
                     ? "min-w-8 min-h-8 bg-secondary bg-opacity-30 rounded-full"
                     : ""
                 }
-                ${savePostDate?.date === date.date ? "min-w-8 min-h-8 bg-primary bg-opacity-30 rounded-full" : ""}
+                ${
+                  savePostDate?.date === date.date
+                    ? "min-w-8 min-h-8 bg-primary bg-opacity-30 rounded-full cursor-pointer "
+                    : ""
+                }
+                ${selectedDate.date === date.date ? "ring-2 ring-primary-2 ring-offset-4" : ""}
                 `}>
               {date.day}
               {isToday(+date.year, +date.month, +date.day) && <small className="text-base text-xs">오늘</small>}

--- a/src/components/calendar/calendar-contents.tsx
+++ b/src/components/calendar/calendar-contents.tsx
@@ -3,13 +3,17 @@ import CalendarContent from "../post/calendar-content";
 
 export default function CalendarContents() {
   const {
-    posts,
+    posts: { data, isLoading },
     calendar: { selectedDate, currentDate },
   } = useCalendarContext();
 
   const [year, month, date] = selectedDate.date.split("-");
 
-  if (posts.length === 0) {
+  if (isLoading) {
+    return <div className="shadow-xl rounded-xl p-4"></div>;
+  }
+
+  if (!isLoading && data.length === 0) {
     return (
       <div className="w-full text-center text-lg font-semibold text-underline mt-10">{`${currentDate.month}달 인증이 존재하지 않습니다.`}</div>
     );
@@ -19,7 +23,7 @@ export default function CalendarContents() {
       {selectedDate.date ? (
         <>
           <div className="text-center text-lg font-semibold">{`${year}년 ${month}월 ${date}일 인증`}</div>
-          {posts
+          {data
             .find((post) => post.date === selectedDate.date)
             ?.posts.map((post) => (
               <CalendarContent key={post.id} post={post} />
@@ -28,7 +32,7 @@ export default function CalendarContents() {
       ) : (
         <>
           <div className="text-center text-lg font-semibold">{`${currentDate.month}월 인증`}</div>
-          {posts
+          {data
             .flatMap((post) => post.posts)
             .map((post) => (
               <CalendarContent key={post.id} post={post} />

--- a/src/components/calendar/calendar-contents.tsx
+++ b/src/components/calendar/calendar-contents.tsx
@@ -1,24 +1,40 @@
-import { ChevronRightIcon } from "@heroicons/react/24/solid";
-import Link from "next/link";
+import useCalendarContext from "./useCalendarContext";
+import CalendarContent from "../post/calendar-content";
 
 export default function CalendarContents() {
+  const {
+    posts,
+    calendar: { selectedDate, currentDate },
+  } = useCalendarContext();
+
+  const [year, month, date] = selectedDate.date.split("-");
+
+  if (posts.length === 0) {
+    return (
+      <div className="w-full text-center text-lg font-semibold text-underline mt-10">{`${currentDate.month}달 인증이 존재하지 않습니다.`}</div>
+    );
+  }
   return (
-    <div className="flex w-full rounded-2xl shadow-xl py-3">
-      <div className="flex flex-col justify-center items-center w-1/5 border-r border-underline">
-        <span className="text-sm">수</span>
-        <div className="text-md">20</div>
-      </div>
-      <div className="flex items-center ">
-        <div className="pl-4 flex flex-col gap-2">
-          <div className="chip text-[11px] w-10">운동</div>
-          <p className="truncate w-56 text-sm">
-            왜 갈수록 체력이 줄어드는거 같은기분ㅋㅋ 5분뛰고 힘들어서 천천히 뛰었더니 8주동안 제일 ..
-          </p>
-        </div>
-        <Link href={`/posts/1`}>
-          <ChevronRightIcon className="size-4" />
-        </Link>
-      </div>
+    <div className="flex flex-col w-full py-3 gap-5">
+      {selectedDate.date ? (
+        <>
+          <div className="text-center text-lg font-semibold">{`${year}년 ${month}월 ${date}일 인증`}</div>
+          {posts
+            .find((post) => post.date === selectedDate.date)
+            ?.posts.map((post) => (
+              <CalendarContent key={post.id} post={post} />
+            ))}
+        </>
+      ) : (
+        <>
+          <div className="text-center text-lg font-semibold">{`${currentDate.month}월 인증`}</div>
+          {posts
+            .flatMap((post) => post.posts)
+            .map((post) => (
+              <CalendarContent key={post.id} post={post} />
+            ))}
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/calendar/calendar-header.tsx
+++ b/src/components/calendar/calendar-header.tsx
@@ -4,7 +4,9 @@ import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/solid";
 import useCalendarContext from "./useCalendarContext";
 
 const CalendarHeader = () => {
-  const { dispatch, currentDate } = useCalendarContext();
+  const {
+    calendar: { dispatch, currentDate },
+  } = useCalendarContext();
 
   return (
     <div className="flex justify-around">
@@ -21,7 +23,7 @@ const CalendarHeader = () => {
         <button onClick={dispatch.handlePrevMonth}>
           <ChevronLeftIcon className="size-5 text-primary" />
         </button>
-        <span>{currentDate.month}</span>
+        <span>{currentDate.month.padStart(2, "0")}</span>
         <button onClick={dispatch.handleNextMonth}>
           <ChevronRightIcon className="size-5 text-primary" />
         </button>

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -1,29 +1,22 @@
 "use client";
 
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode } from "react";
+
 import { CalendarContext } from "./useCalendarContext";
 import CalendarHeader from "./calendar-header";
 import CalendarBody from "./calendar-body";
 import SelectedDate from "./seleted-date";
 import useCalendar from "@/hooks/useCalendar";
 import CalendarContents from "./calendar-contents";
-import { getWrittenPostByYearnAndMonth } from "@/app/(tab)/calendar/actions";
-import { GroupPostsByDateType } from "@/lib/utils";
+import useGetCalendarPosts from "@/hooks/useGetCalendarPosts";
 
 const Calendar = ({ children }: { children: ReactNode }) => {
   const calendar = useCalendar();
   const { year, month } = calendar.currentDate;
-  const [calendarPosts, setCalendarPosts] = useState<GroupPostsByDateType>([]);
-  useEffect(() => {
-    const fetchingPostsByCalendar = async () => {
-      const posts = await getWrittenPostByYearnAndMonth(Number(year), Number(month));
-      setCalendarPosts(posts);
-    };
-    fetchingPostsByCalendar();
-  }, [year, month]);
+  const { calendarPosts, isLoading } = useGetCalendarPosts(Number(year), Number(month));
 
   return (
-    <CalendarContext.Provider value={{ calendar, posts: calendarPosts }}>
+    <CalendarContext.Provider value={{ calendar, posts: { data: calendarPosts, isLoading } }}>
       <div className="flex flex-col gap-2 w-full">{children}</div>
     </CalendarContext.Provider>
   );

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -1,17 +1,29 @@
 "use client";
 
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { CalendarContext } from "./useCalendarContext";
 import CalendarHeader from "./calendar-header";
 import CalendarBody from "./calendar-body";
 import SelectedDate from "./seleted-date";
 import useCalendar from "@/hooks/useCalendar";
 import CalendarContents from "./calendar-contents";
+import { getWrittenPostByYearnAndMonth } from "@/app/(tab)/calendar/actions";
+import { GroupPostsByDateType } from "@/lib/utils";
 
 const Calendar = ({ children }: { children: ReactNode }) => {
   const calendar = useCalendar();
+  const { year, month } = calendar.currentDate;
+  const [calendarPosts, setCalendarPosts] = useState<GroupPostsByDateType>([]);
+  useEffect(() => {
+    const fetchingPostsByCalendar = async () => {
+      const posts = await getWrittenPostByYearnAndMonth(Number(year), Number(month));
+      setCalendarPosts(posts);
+    };
+    fetchingPostsByCalendar();
+  }, [year, month]);
+
   return (
-    <CalendarContext.Provider value={calendar}>
+    <CalendarContext.Provider value={{ calendar, posts: calendarPosts }}>
       <div className="flex flex-col gap-2 w-full">{children}</div>
     </CalendarContext.Provider>
   );

--- a/src/components/calendar/seleted-date.tsx
+++ b/src/components/calendar/seleted-date.tsx
@@ -3,7 +3,9 @@
 import useCalendarContext from "./useCalendarContext";
 
 const SelectedDate = () => {
-  const { selectedDate } = useCalendarContext();
+  const {
+    calendar: { selectedDate },
+  } = useCalendarContext();
   return <div>{selectedDate.date}</div>;
 };
 

--- a/src/components/calendar/useCalendarContext.ts
+++ b/src/components/calendar/useCalendarContext.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { GroupPostsByDateType } from "@/lib/utils";
 import { createContext, useContext } from "react";
 
 interface DateInfo {
@@ -8,18 +9,21 @@ interface DateInfo {
   day: string;
 }
 interface CalendarContextType {
-  currentDate: DateInfo;
-  daysInMonth: (DateInfo & { date: string; dayIndexOfWeek: number })[];
-  dispatch: {
-    handlePrevYear: () => void;
-    handleNextYear: () => void;
-    handlePrevMonth: () => void;
-    handleNextMonth: () => void;
+  calendar: {
+    currentDate: DateInfo;
+    daysInMonth: (DateInfo & { date: string; dayIndexOfWeek: number })[];
+    dispatch: {
+      handlePrevYear: () => void;
+      handleNextYear: () => void;
+      handlePrevMonth: () => void;
+      handleNextMonth: () => void;
+    };
+    selectedDate: {
+      date: string;
+      selectDate: (date: string) => void;
+    };
   };
-  selectedDate: {
-    date: string;
-    selectDate: (date: string) => void;
-  };
+  posts: GroupPostsByDateType;
 }
 
 export const CalendarContext = createContext<CalendarContextType | null>(null);

--- a/src/components/calendar/useCalendarContext.ts
+++ b/src/components/calendar/useCalendarContext.ts
@@ -23,7 +23,10 @@ interface CalendarContextType {
       selectDate: (date: string) => void;
     };
   };
-  posts: GroupPostsByDateType;
+  posts: {
+    data: GroupPostsByDateType;
+    isLoading: boolean;
+  };
 }
 
 export const CalendarContext = createContext<CalendarContextType | null>(null);

--- a/src/components/post/calendar-content.tsx
+++ b/src/components/post/calendar-content.tsx
@@ -1,0 +1,26 @@
+import { ChevronRightIcon } from "@heroicons/react/24/solid";
+import { Post } from "@prisma/client";
+import Link from "next/link";
+
+import { WEEKS } from "@/constants/calendar";
+import { CATEGORIES } from "@/constants/cateogries";
+
+export default function CalendarContent({ post }: { post: Post }) {
+  return (
+    <div className="flex w-full h-[73px] rounded-2xl shadow-xl">
+      <div className="flex flex-col justify-center items-center w-1/5 border-r border-underline">
+        <span className="text-sm">{WEEKS[post.created_at.getDay()]}</span>
+        <div className="text-md">{post.created_at.getDate()}</div>
+      </div>
+      <div className="flex items-center w-full">
+        <div className="pl-4 flex flex-col gap-2">
+          <div className="chip text-[11px] w-10">{CATEGORIES[post.category]}</div>
+          <p className="truncate w-56 text-sm">{post.description}</p>
+        </div>
+        <Link href={`/posts/${post.id}`} className="ml-auto">
+          <ChevronRightIcon className="size-4" />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/post/calendar-content.tsx
+++ b/src/components/post/calendar-content.tsx
@@ -17,8 +17,8 @@ export default function CalendarContent({ post }: { post: Post }) {
           <div className="chip text-[11px] w-10">{CATEGORIES[post.category]}</div>
           <p className="truncate w-56 text-sm">{post.description}</p>
         </div>
-        <Link href={`/posts/${post.id}`} className="ml-auto">
-          <ChevronRightIcon className="size-4" />
+        <Link href={`/posts/${post.id}`} className="ml-auto p-5">
+          <ChevronRightIcon className="size-5" />
         </Link>
       </div>
     </div>

--- a/src/components/post/status-card.tsx
+++ b/src/components/post/status-card.tsx
@@ -4,12 +4,12 @@ export default async function StatusCard() {
   const postAllCount = await getPostCountByLoggedInUser();
   const postCountForThisMonth = await getPostCountForThisMonth();
   return (
-    <div className="flex justify-around">
-      <div className=" *:font-semibold flex flex-col gap-1 items-center ">
+    <div className="flex justify-around w-full *:py-5 *:gap-2 ">
+      <div className=" *:font-semibold flex flex-col items-center ">
         <span>누적 인증</span>
         <div className="chip w-[60px]">{postAllCount}</div>
       </div>
-      <div className=" *:font-semibold flex flex-col gap-1 items-center ">
+      <div className=" *:font-semibold flex flex-col items-center ">
         <span>이번달 인증</span>
         <div className="chip w-[60px]">{postCountForThisMonth}</div>
       </div>

--- a/src/constants/calendar.ts
+++ b/src/constants/calendar.ts
@@ -1,0 +1,1 @@
+export const WEEKS = ["일", "월", "화", "수", "목", "금", "토"] as const;

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -15,8 +15,8 @@ import { useState } from "react";
 
 const useCalendar = () => {
   const [currentDate, setCurrentDate] = useState(new Date());
-  const [currentYear, currentMonth, currentDay] = format(currentDate, "yyyy-MM-d").split("-");
-  const [selectedDate, setSelectedDate] = useState<string>(format(new Date(), "yyyy-MM-d"));
+  const [currentYear, currentMonth, currentDay] = format(currentDate, "yyyy-M-d").split("-");
+  const [selectedDate, setSelectedDate] = useState<string>("");
 
   const startCurrentMonth = startOfMonth(currentDate);
   const endCurrentMonth = endOfMonth(currentDate);
@@ -29,26 +29,30 @@ const useCalendar = () => {
   });
   const handlePrevYear = () => {
     setCurrentDate((prevDate) => subYears(prevDate, 1));
+    setSelectedDate("");
   };
 
   const handleNextYear = () => {
     setCurrentDate((prevDate) => addYears(prevDate, 1));
+    setSelectedDate("");
   };
   const handlePrevMonth = () => {
     setCurrentDate((prevDate) => subMonths(prevDate, 1));
+    setSelectedDate("");
   };
 
   const handleNextMonth = () => {
     setCurrentDate((prevDate) => addMonths(prevDate, 1));
+    setSelectedDate("");
   };
 
   const handleSelectDate = (date: string) => {
     setSelectedDate(date);
   };
   const daysInMonth = days.map((day) => ({
-    date: format(day, "yyyy-MM-d"),
+    date: format(day, "yyyy-M-d"),
     year: format(day, "yyyy"),
-    month: format(day, "MM"),
+    month: format(day, "M"),
     day: format(day, "d"),
     dayIndexOfWeek: getDay(day),
   }));

--- a/src/hooks/useGetCalendarPosts.ts
+++ b/src/hooks/useGetCalendarPosts.ts
@@ -1,0 +1,25 @@
+import { getWrittenPostByYearnAndMonth } from "@/app/(tab)/calendar/actions";
+import { GroupPostsByDateType } from "@/lib/utils";
+import { useEffect, useState } from "react";
+
+export default function useGetCalendarPosts(year: number, month: number) {
+  const [calendarPosts, setCalendarPosts] = useState<GroupPostsByDateType>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    const fetchingPostsByCalendar = async () => {
+      try {
+        setIsLoading(true);
+        const posts = await getWrittenPostByYearnAndMonth(Number(year), Number(month));
+        setCalendarPosts(posts);
+      } catch (error) {
+        console.error(error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchingPostsByCalendar();
+  }, [year, month]);
+
+  return { calendarPosts, isLoading };
+}

--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -1,7 +1,23 @@
-import { Category } from "@prisma/client";
+import { Category, Post } from "@prisma/client";
 
 import { CATEGORIES } from "@/constants/cateogries";
+import { format } from "date-fns";
 
 export const isCategory = (category: string): category is Category => {
   return Object.keys(CATEGORIES).includes(category);
+};
+
+export type GroupPostsByDateType = ReturnType<typeof groupPostsByDate>;
+
+export const groupPostsByDate = (posts: Post[]) => {
+  const groutPostsObject = posts.reduce((acc, post) => {
+    const dateKey = format(new Date(post.created_at), "yyyy-M-d");
+    if (!acc[dateKey]) {
+      acc[dateKey] = [];
+    }
+    acc[dateKey].push(post);
+    return acc;
+  }, {} as Record<string, Post[]>);
+  const groupPosts = Object.entries(groutPostsObject).map(([date, posts]) => ({ date, posts }));
+  return groupPosts;
 };


### PR DESCRIPTION
Close #19

## 변경사항
### 캘린더 기능 구현 
- (년, 월)에 따라 로그인 사용자가 작성한 post를 렌더링 한다.
- 최초 진입시, 사용자가 년 또는 월을 변경할 떄는 해당되는 년과 월의 데이터를 전부 렌더링 한다.
- 사용자가 캘린더 범위의 특정 날짜에 post를 작성하였을 경우 캘린더에 표시한다.
   -  스타일링 된 것을 클릭할 경우 해당 날짜에 작성된 post 목록을 간략하게 보여준다.

|최초 진입 | 특정 년 또는 월을 변경 | 특정 날짜를 선택(post가 저장된 날짜만 접근 가능)|
|-|-|-|
|<img width="662" alt="image" src="https://github.com/user-attachments/assets/887d4adc-08d3-4b7f-8ddc-116ee39095e3">|<img width="650" alt="image" src="https://github.com/user-attachments/assets/6c957e5c-bb1c-420d-ba3d-a7813d3a933a">|<img width="649" alt="image" src="https://github.com/user-attachments/assets/b46a449f-2f83-4920-8d48-38fa65051d28">


## 추가사항
