### PR TITLE
Feature #39 view count error of detail post

### DIFF
--- a/src/components/post/comment.tsx
+++ b/src/components/post/comment.tsx
@@ -4,7 +4,7 @@ import { useOptimistic } from "react";
 import { ChatBubbleBottomCenterTextIcon } from "@heroicons/react/24/solid";
 
 import { addPostComment, deleteComment } from "@/app/(tab)/posts/[id]/actions";
-import { InitialComments } from "@/app/(tab)/posts/[id]/page";
+import { InitialComments } from "@/service/commentService";
 import { commentSchema } from "@/lib/schema";
 import DeleteButton from "../common/delete-button";
 

--- a/src/service/commentService.ts
+++ b/src/service/commentService.ts
@@ -1,0 +1,23 @@
+import db from "@/lib/server/db";
+import { Prisma } from "@prisma/client";
+
+export async function getInitialComments(postId: number, userId: number) {
+  const comments = await db.comment.findMany({
+    where: {
+      postId,
+    },
+    select: {
+      id: true,
+      text: true,
+      created_at: true,
+      user: {
+        select: {
+          id: true,
+          username: true,
+        },
+      },
+    },
+  });
+  return comments.map((comment) => ({ ...comment, isAuthor: comment.user.id === userId }));
+}
+export type InitialComments = Prisma.PromiseReturnType<typeof getInitialComments>;

--- a/src/service/likeService.ts
+++ b/src/service/likeService.ts
@@ -1,0 +1,21 @@
+import db from "@/lib/server/db";
+
+export async function getLikeStatus(postId: number, userId: number) {
+  const like = await db.like.findUnique({
+    where: {
+      id: {
+        userId,
+        postId,
+      },
+    },
+  });
+  const likeCount = await db.like.count({
+    where: {
+      postId,
+    },
+  });
+  return {
+    isLiked: Boolean(like),
+    likeCount,
+  };
+}

--- a/src/service/postService.ts
+++ b/src/service/postService.ts
@@ -123,3 +123,34 @@ export async function getPostCountByLoggedInUser() {
 
   return postCount;
 }
+
+export async function getPostById(id: number) {
+  return db.post.findUnique({ where: { id } });
+}
+
+export async function getPostWithUpdateView(id: number) {
+  const post = await db.post.update({
+    where: {
+      id,
+    },
+    data: {
+      views: {
+        increment: 1,
+      },
+    },
+    include: {
+      _count: {
+        select: {
+          comments: true,
+        },
+      },
+      user: {
+        select: {
+          username: true,
+          avatar: true,
+        },
+      },
+    },
+  });
+  return post;
+}


### PR DESCRIPTION
# 트러블 슈팅

Close #39 

## 이슈
글 작성 이후 자동으로 라우팅되는 글 상세 페이지에서 최초 조회수가 1이 아니다.


## 해결

### 최초 조회수 1 증가 에러 해결

글 상세페이지 진입시, 조회수를 증가시키며 글 상세 데이터를 조회하는 쿼리 함수를 한 번만 호출하는 것이 아니었습니다.
한 번만 호출 하게 변경하고, 추가적으로 상세 페이지에 대한 정보가 필요한 경우에는 조회수를 증가시키지않고 조회하는 쿼리를 따로 생성하였습니다.

## 추가사항
- 코드 파일 분리 