### PR TITLE
Feature #47 공통에러 처리로 인한 사이드이펙트 고려: ai comment 에러 수정

### DIFF
--- a/src/service/aiCommentService.ts
+++ b/src/service/aiCommentService.ts
@@ -1,9 +1,9 @@
 import AWS from "aws-sdk";
 
 import db from "@/lib/server/db";
-import { NOT_EXISTS_AI_COMMENT_MESSAGE, NOT_EXISTS_POST_MESSAGE } from "@/constants/messages";
+import { NOT_EXISTS_POST_MESSAGE } from "@/constants/messages";
 import { NotFoundError } from "@/lib/error/customError";
-import { withErrorHandling } from "@/lib/error/withErrorHandling";
+import { createSuccessResponse } from "@/lib/server/createServerResponse";
 
 const sqs = new AWS.SQS({ region: "ap-northeast-2" });
 
@@ -29,7 +29,7 @@ export const sendAiCommentToSQS = async (messageBody: MessageBody): Promise<stri
   }
 };
 
-export const fetchInitialComment = withErrorHandling(async (postId: number) => {
+export const fetchInitialComment = async (postId: number) => {
   const post = await db.post.findUnique({
     where: {
       id: postId,
@@ -51,8 +51,5 @@ export const fetchInitialComment = withErrorHandling(async (postId: number) => {
   }));
 
   const [firstAiComment] = aiComments;
-  if (!firstAiComment) {
-    throw new NotFoundError(NOT_EXISTS_AI_COMMENT_MESSAGE);
-  }
-  return { data: firstAiComment };
-});
+  return createSuccessResponse({ data: firstAiComment ?? null });
+};

--- a/src/service/aiCommentService.ts
+++ b/src/service/aiCommentService.ts
@@ -51,5 +51,7 @@ export const fetchInitialComment = async (postId: number) => {
   }));
 
   const [firstAiComment] = aiComments;
+  // 글 작성시, ai comment가 존재하지 않기 않는다.
+  // null 값으로 주어 ai comment가 등록되지 않은 상태로 명시하여, 비동기적으로 ai comment를 생성하고 등록하는 시간 동안 로딩상태를 보여준다.
   return createSuccessResponse({ data: firstAiComment ?? null });
 };


### PR DESCRIPTION
close #47 

## 변경사항 
공통에러 처리로 인한 사이드이펙트 발생
- 글 작성시에는 ai comment 가 존재하지 않는다.
- 그러므로, 공통 에러처리 로직을 진행할 경우에는 not found 에러를 던지게 된다.

이로인해 공통 에러 처리를 다시 구축 하는 것을 고려할 필요가 있다.
Next.js 에서는 서버액션에서는 try catch 사용을 지양하고, 값반 반환하는 것을 권한다.
또한, 클라이언트에서 에러를 표시해주고 싶은 경우에는 useFormState과 error.tsx 을 사용하는 것을 권한다.

현재는 권하는 것과 동일하게 form을 사용하는 곳에서는 useFormState을 사용하고 에러를 throw 해서 error.tsx를 사용하고 있다
하지만, 값만 반환하는 것이 아니고 서버액션에서 try catch문 => 세부적인 error 처리 및 직렬화 => 컴포넌트에서 에러 throw 로직을 진행하는 상황이다.

프로젝트에서 발생할 수있는 다양한 에러 상황을 고려하여 공통 에러처리 수정이 필요해보인다.
- 상충되는 상황
     - 데이터가 존재하지 않을 경우 => not fond 
     - 인증 기록시 ai comment는 존재하지 않는다 => Not found에러를 던지면 안된다.

## 레퍼런스
https://nextjs.org/docs/app/building-your-application/routing/error-handling

## 추가 변경 계획
- 에러 처리에 대한 문서화 진행 계획