### PR TITLE
Feature #54 업로드 페이지에서 주제 선택 이슈 처리

### DIFF
--- a/src/components/post/upload-form.tsx
+++ b/src/components/post/upload-form.tsx
@@ -74,9 +74,11 @@ export default function UploadForm() {
           <p className="text-md font-bold">주제</p>
           <p className="text-neutral text-sm">작성하신 인증 주제를 1가지 선택해주세요.</p>
           <div className="flex flex-wrap gap-1">
-            {Object.entries(CATEGORIES).map(([value, title]) => (
-              <InputChip key={value} value={value} type="radio" title={title} {...register("category")} />
-            ))}
+            {Object.entries(CATEGORIES)
+              .slice(1)
+              .map(([value, title]) => (
+                <InputChip key={value} value={value} type="radio" title={title} {...register("category")} />
+              ))}
           </div>
           <p className="text-error">{errors.category?.message}</p>
         </div>

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -64,8 +64,8 @@ export const postSchema = z.object({
       required_error: "자세한 설명은 필수 값입니다.",
     })
     .trim()
-    .min(1, "자세한 설명은 빈 값이 될 수 없습니다."),
-  category: z.string().refine(isCategory, "잘못된 주제선택입니다."),
+    .min(1, "자세한 설명을 입력해주세요."),
+  category: z.string({ message: "해당하는 주제를 선택해주세요" }).refine(isCategory, "잘못된 주제선택입니다."),
 });
 
 export const commentSchema = z


### PR DESCRIPTION
Close #54 

### 업로드 페이지에서 주제 중 [전체] 선택지 제거

- 카테고리 중 전체 조회시 사용할 용도로 사용되는 값이기 떄문에 업로드 페이지에서는 [전체] 선택지를 제외하였습니다.

<img width="610" alt="image" src="https://github.com/user-attachments/assets/6c0326b9-f9f2-45cb-b617-693715795919">


### 업로드 페이지에서의 에러메시지 보완

- 사용자가 인식할 수 있는 에러메시지로 보완하였습니다.

<img width="522" alt="image" src="https://github.com/user-attachments/assets/163e098e-ac46-4af2-9cd4-9a6e7272a323">

