### PR TITLE
Feature #56 등록 이미지 URL 관련

### DIFF
--- a/src/app/(tab)/posts/[id]/page.tsx
+++ b/src/app/(tab)/posts/[id]/page.tsx
@@ -35,7 +35,7 @@ export async function generateMetadata({ params }: { params: { id: string } }): 
       url: `https://boostpal.vercel.app/posts/${product.id}`,
       images: [
         {
-          url: product.photo ? `${product.photo}/middle` : "/images/og-image.jpg",
+          url: product.photo ? product.photo : "/images/og-image.jpg",
           width: 800,
           height: 600,
           alt: product.description.slice(0, 10),

--- a/src/app/(tab)/users/[username]/edit/actions.ts
+++ b/src/app/(tab)/users/[username]/edit/actions.ts
@@ -12,7 +12,7 @@ import { PASSWORD_ERROR_MESSAGE, USER_INFO_ERROR_MESSAGE } from "@/constants/mes
 import { cacheTags } from "@/lib/cacheTags";
 import { generateErrorResponse } from "@/lib/error/generateErrorResponse";
 import { ValidationError } from "@/lib/error/customError";
-import { createUploadImageUrl } from "@/lib/images";
+import { createUploadImageUrl, IMAGES_OPTIONS } from "@/lib/images";
 
 export const editProfile = async (formData: FormData) => {
   const data = {
@@ -49,7 +49,7 @@ export const editProfile = async (formData: FormData) => {
           username: result.data?.username,
           password: hashedNewPassword,
           bio: result.data?.bio,
-          avatar: createUploadImageUrl(result.data.photo, "small"),
+          avatar: createUploadImageUrl(result.data.photo, IMAGES_OPTIONS.SMALL),
         },
       });
     }
@@ -63,7 +63,7 @@ export const editProfile = async (formData: FormData) => {
         username: result.data?.username,
         password: loggedInUser?.password,
         bio: result.data?.bio,
-        avatar: createUploadImageUrl(result.data.photo, "small"),
+        avatar: createUploadImageUrl(result.data.photo, IMAGES_OPTIONS.SMALL),
       },
     });
   } catch (error) {

--- a/src/app/(tab)/users/[username]/edit/actions.ts
+++ b/src/app/(tab)/users/[username]/edit/actions.ts
@@ -12,6 +12,7 @@ import { PASSWORD_ERROR_MESSAGE, USER_INFO_ERROR_MESSAGE } from "@/constants/mes
 import { cacheTags } from "@/lib/cacheTags";
 import { generateErrorResponse } from "@/lib/error/generateErrorResponse";
 import { ValidationError } from "@/lib/error/customError";
+import { createUploadImageUrl } from "@/lib/images";
 
 export const editProfile = async (formData: FormData) => {
   const data = {
@@ -48,7 +49,7 @@ export const editProfile = async (formData: FormData) => {
           username: result.data?.username,
           password: hashedNewPassword,
           bio: result.data?.bio,
-          avatar: result.data.photo ?? "",
+          avatar: createUploadImageUrl(result.data.photo, "small"),
         },
       });
     }
@@ -62,7 +63,7 @@ export const editProfile = async (formData: FormData) => {
         username: result.data?.username,
         password: loggedInUser?.password,
         bio: result.data?.bio,
-        avatar: result.data.photo ?? "",
+        avatar: createUploadImageUrl(result.data.photo, "small"),
       },
     });
   } catch (error) {

--- a/src/app/upload/actions.ts
+++ b/src/app/upload/actions.ts
@@ -9,6 +9,7 @@ import { ServerResponse } from "@/lib/types";
 import { formatZodErrorMessage } from "@/lib/utils";
 import { generateErrorResponse } from "@/lib/error/generateErrorResponse";
 import { getSessionId } from "@/service/userService";
+import { createUploadImageUrl } from "@/lib/images";
 
 export const uploadPost = async (formData: FormData): Promise<ServerResponse<unknown>> => {
   let postId: number;
@@ -41,7 +42,7 @@ export const uploadPost = async (formData: FormData): Promise<ServerResponse<unk
     sendAiCommentToSQS({
       postId: post.id,
       userId: post.userId,
-      imageUrl: post.photo ? `${post.photo}/middle` : "",
+      imageUrl: createUploadImageUrl(post.photo, "middle"),
       description: post.description,
     });
   } catch (error) {

--- a/src/app/upload/actions.ts
+++ b/src/app/upload/actions.ts
@@ -9,7 +9,7 @@ import { ServerResponse } from "@/lib/types";
 import { formatZodErrorMessage } from "@/lib/utils";
 import { generateErrorResponse } from "@/lib/error/generateErrorResponse";
 import { getSessionId } from "@/service/userService";
-import { createUploadImageUrl } from "@/lib/images";
+import { createUploadImageUrl, IMAGES_OPTIONS } from "@/lib/images";
 
 export const uploadPost = async (formData: FormData): Promise<ServerResponse<unknown>> => {
   let postId: number;
@@ -42,7 +42,7 @@ export const uploadPost = async (formData: FormData): Promise<ServerResponse<unk
     sendAiCommentToSQS({
       postId: post.id,
       userId: post.userId,
-      imageUrl: createUploadImageUrl(post.photo, "middle"),
+      imageUrl: createUploadImageUrl(post.photo, IMAGES_OPTIONS.MIDDLE),
       description: post.description,
     });
   } catch (error) {

--- a/src/components/common/user-default-image.tsx
+++ b/src/components/common/user-default-image.tsx
@@ -18,7 +18,7 @@ export default function UserDefaultImage({
     <div className={`relative rounded-full ${style}`}>
       {avatar ? (
         <Image
-          src={`${avatar.includes("imagedelivery") ? avatar + "/small" : avatar}`}
+          src={avatar}
           className={`rounded-full aspect-square w-full`}
           width={width}
           height={height}

--- a/src/components/user/profile-edit-form.tsx
+++ b/src/components/user/profile-edit-form.tsx
@@ -3,6 +3,7 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { UserIcon } from "@heroicons/react/24/solid";
+import { User } from "@prisma/client";
 
 import Button from "../common/button";
 import Input from "../common/input";
@@ -12,12 +13,9 @@ import { editProfile } from "@/app/(tab)/users/[username]/edit/actions";
 import { createBlurValidation } from "@/lib/client/form-validate";
 import { checkEmailAvailability, checkUsernameAvailability } from "@/lib/server/validate";
 import { EMAIL_ERROR_MESSAGE, USERNAME_ERROR_MESSAGE } from "@/constants/messages";
-import { User } from "@prisma/client";
 
 export default function ProfileEditForm({ initialUserInformation }: { initialUserInformation: User }) {
-  const { dispatch, state } = useUploadImage(
-    initialUserInformation.avatar ? `${initialUserInformation.avatar}/small` : ""
-  );
+  const { dispatch, state } = useUploadImage(initialUserInformation.avatar ?? "");
 
   const {
     register,
@@ -35,6 +33,7 @@ export default function ProfileEditForm({ initialUserInformation }: { initialUse
       photo: initialUserInformation.avatar ?? "",
     },
   });
+
   const onBlurUsername = createBlurValidation(checkUsernameAvailability, setError, "username", USERNAME_ERROR_MESSAGE);
   const onBlurEmail = createBlurValidation(checkEmailAvailability, setError, "email", EMAIL_ERROR_MESSAGE);
 

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -1,0 +1,12 @@
+export const IMAGES_OPTIONS = {
+  SMALL: "small",
+  MIDDLE: "middle",
+} as const;
+
+export const createUploadImageUrl = (
+  imageUrl?: string,
+  option?: (typeof IMAGES_OPTIONS)[keyof typeof IMAGES_OPTIONS]
+) => {
+  if (!imageUrl) return "";
+  return option ? `${imageUrl}/${option}` : imageUrl;
+};

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -7,6 +7,8 @@ export const createUploadImageUrl = (
   imageUrl?: string,
   option?: (typeof IMAGES_OPTIONS)[keyof typeof IMAGES_OPTIONS]
 ) => {
-  if (!imageUrl) return "";
+  if (!imageUrl) {
+    return "";
+  }
   return option ? `${imageUrl}/${option}` : imageUrl;
 };


### PR DESCRIPTION
Closes #56

## 변경사항 

> #58  방법으로 변경
> 최종 변경 안은 #58 을 확인해주세요.

### 애플리케이션에서 등록된 이지미와 외부에서 등록된 이미지 관리 변경

현재 프로젝트에서 사용되는 모든 이미지는 clouseflare에 등록됩니다.
최초 설계시, cloudflare에서 제공하는 다양한 리사이징을 지원받기 위해 데이터베이스 등록시 전체 이미지 URL을 등록하지 않았습니다. 
실제 이미지를 렌더링할때 리사이징 옵션을 붙여 이미지를 불러왔습니다.

하지만, 소셜 로그인이 추가되고 나서 해당 애플리케이션에서 등록하지않은 이미지를 불러오는 것에 분기처리가 추가되어야했습니다.
이미지컴포넌트는 링크에 `imagedelivery` 이 포함되어있는지 (cloudflare에 등록된 이미지 인지 확인) 확인이 필요하였고, 만약 맞다면 그것에 대한 리사이징이 추가적으로 필요했습니다.
 
이를 해결하기위해서 어플리케이션에서 이미지를 데이터베이스 등록시에 리사이징 처리한 완전한 URL로 등록하여 클라이언트에서 이미지를 불러올때 분기처리 없이 통일성 있게 불러오는 것으로 변경합니다.


### ~~cloudflare등록 이미지 URL 포매팅 관련 함수 생성~~

~~등록할 때 부터 리사이징을 적용한 완전한 URL을 만들기 위해 함수를 생성했습니다.
추후에 리사이징 옵션이 추가될때 적용하기위해 옵션은 상수화 처리했습니다.~~

```ts
export const IMAGES_OPTIONS = {
  SMALL: "small",
  MIDDLE: "middle",
} as const;

export const createUploadImageUrl = (
  imageUrl?: string,
  option?: (typeof IMAGES_OPTIONS)[keyof typeof IMAGES_OPTIONS]
) => {
  if (!imageUrl) return "";
  return option ? `${imageUrl}/${option}` : imageUrl;
};

```
